### PR TITLE
fix(scoring): exclude byes from MWP/GWP per official OP TCG rules

### DIFF
--- a/tournaments/scoring.py
+++ b/tournaments/scoring.py
@@ -2,10 +2,16 @@
 One Piece TCG official scoring and tiebreakers.
 
 Ranking order:
-  1. Match Points (MP)  — Win=3, Draw=1, Loss=0
+  1. Match Points (MP)  — Win=3, Draw=1, Loss=0 (a BYE is worth a full win = 3 MP)
   2. Opponent Match Win % (OMW%) — Average of opponents' match-win%, floored at 33%
   3. Game Win % (GW%)   — player's game-wins / total-games-played
   4. Opponent Game Win % (OGW%) — average of opponents' GW%, floored at 33%
+
+BYE handling (per official Bandai / Wizards-style Swiss rules):
+  A bye counts as a 2-0 match win for *match points only*. It is NOT included
+  in the recipient's Match-Win % or Game-Win % (neither numerator nor
+  denominator), so it cannot inflate their own tiebreakers nor their
+  opponents' OMW%/OGW%.
 """
 from __future__ import annotations
 
@@ -18,18 +24,17 @@ WIN_POINTS = Decimal(3)
 DRAW_POINTS = Decimal(1)
 LOSS_POINTS = Decimal(0)
 FLOOR = Decimal("0.33")
-BYE_GAME_WINS = 2
-BYE_GAME_LOSSES = 0
 
 
 @dataclass
 class PlayerStats:
     player: TournamentPlayer
-    match_wins: int = 0
+    match_wins: int = 0  # wins in *played* matches (excludes byes)
     match_draws: int = 0
     match_losses: int = 0
-    game_wins: int = 0
-    game_losses: int = 0
+    bye_wins: int = 0  # byes received; counted in MP only, NOT in MWP/GWP
+    game_wins: int = 0  # games won in *played* matches (excludes byes)
+    game_losses: int = 0  # games lost in *played* matches (excludes byes)
     opponents: list[int] = field(default_factory=list)  # list of TournamentPlayer PKs
 
     @property
@@ -38,21 +43,31 @@ class PlayerStats:
             WIN_POINTS * self.match_wins
             + DRAW_POINTS * self.match_draws
             + LOSS_POINTS * self.match_losses
+            + WIN_POINTS * self.bye_wins
         )
 
     @property
     def matches_played(self) -> int:
+        """Number of *played* matches (excludes byes), used for MWP."""
         return self.match_wins + self.match_draws + self.match_losses
 
     @property
     def match_win_percentage(self) -> Decimal:
+        """
+        MWP from played matches only (byes excluded from numerator and denominator),
+        floored at 33%.
+        """
         played = self.matches_played
         if played == 0:
             return FLOOR
-        return max(self.match_points / (played * WIN_POINTS), FLOOR)
+        played_points = (
+            WIN_POINTS * self.match_wins + DRAW_POINTS * self.match_draws
+        )
+        return max(played_points / (played * WIN_POINTS), FLOOR)
 
     @property
     def game_win_percentage(self) -> Decimal:
+        """GWP from played matches only (bye games excluded), floored at 33%."""
         total = self.game_wins + self.game_losses
         if total == 0:
             return FLOOR
@@ -102,9 +117,9 @@ def _gather_stats(tournament: Tournament) -> dict[int, PlayerStats]:
             continue
 
         if match.is_bye:
-            s1.match_wins += 1
-            s1.game_wins += BYE_GAME_WINS
-            s1.game_losses += BYE_GAME_LOSSES
+            # Bye: counts toward match points only, NOT toward MWP/GWP or
+            # opponent tiebreakers.
+            s1.bye_wins += 1
             continue
 
         p2_pk = match.player2_id
@@ -169,7 +184,9 @@ def compute_standings(tournament: Tournament) -> list[StandingRow]:
                 rank=0,
                 player=ps.player,
                 match_points=ps.match_points,
-                wins=ps.match_wins,
+                # Display wins include byes so the standings table reflects
+                # the player's record (a bye is still a match win on paper).
+                wins=ps.match_wins + ps.bye_wins,
                 draws=ps.match_draws,
                 losses=ps.match_losses,
                 omw_pct=calc_omw(ps),

--- a/tournaments/tests/test_scoring.py
+++ b/tournaments/tests/test_scoring.py
@@ -1,0 +1,143 @@
+"""
+Tests for OP TCG scoring & tiebreakers.
+
+These tests focus on the official-rule requirement that a BYE counts
+toward Match Points but is excluded from the Match-Win % and Game-Win %
+used for tiebreakers (both for the BYE recipient and for their opponents).
+"""
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from accounts.models import PlayerProfile
+from tournaments.models import EventType, Match, Round, Tournament, TournamentPlayer
+from tournaments.scoring import FLOOR, compute_standings
+
+User = get_user_model()
+
+
+def _make_user(idx: int) -> User:
+    user = User.objects.create_user(username=f"p{idx}", password="x")
+    PlayerProfile.objects.create(user=user, display_name=f"Player {idx}")
+    return user
+
+
+class ByeTiebreakerTests(TestCase):
+    def setUp(self):
+        self.event_type = EventType.objects.create(name="Standard")
+        self.admin = _make_user(0)
+        self.tournament = Tournament.objects.create(
+            name="T",
+            event_type=self.event_type,
+            created_by=self.admin,
+            max_rounds=3,
+            current_round=0,
+        )
+        self.players = []
+        for i in range(1, 5):
+            user = _make_user(i)
+            self.players.append(
+                TournamentPlayer.objects.create(
+                    tournament=self.tournament, user=user, seed=i
+                )
+            )
+
+    def _round(self, number: int) -> Round:
+        return Round.objects.create(
+            tournament=self.tournament,
+            number=number,
+            status=Round.Status.COMPLETED,
+        )
+
+    def _played(self, rnd, p1, p2, s1, s2):
+        Match.objects.create(
+            round=rnd,
+            player1=p1,
+            player2=p2,
+            player1_score=s1,
+            player2_score=s2,
+            player1_confirmed=True,
+            player2_confirmed=True,
+            confirmed=True,
+            is_bye=False,
+        )
+
+    def _bye(self, rnd, player):
+        Match.objects.create(
+            round=rnd,
+            player1=player,
+            player2=None,
+            player1_score=2,
+            player2_score=0,
+            player1_confirmed=True,
+            player2_confirmed=True,
+            confirmed=True,
+            is_bye=True,
+        )
+
+    def test_bye_counts_as_3_match_points(self):
+        """A BYE must award full match points (3)."""
+        r1 = self._round(1)
+        self._bye(r1, self.players[0])
+
+        rows = compute_standings(self.tournament)
+        row = next(r for r in rows if r.player.pk == self.players[0].pk)
+        self.assertEqual(row.match_points, Decimal(3))
+        self.assertEqual(row.wins, 1)  # display still shows 1 win
+
+    def test_bye_does_not_inflate_recipient_mwp_or_gwp(self):
+        """
+        Per official rules, a BYE is excluded from MWP and GWP.
+
+        Recipient: 1 BYE + 1 played loss (0-2). MWP must be the floor (33%),
+        not 50% (which would be the case if the BYE was counted as a win).
+        """
+        r1 = self._round(1)
+        r2 = self._round(2)
+        # P1 gets a bye in round 1, then loses 0-2 to P2 in round 2
+        self._bye(r1, self.players[0])
+        self._played(r2, self.players[0], self.players[1], 0, 2)
+
+        rows = compute_standings(self.tournament)
+        p1_row = next(r for r in rows if r.player.pk == self.players[0].pk)
+
+        # GWP from played matches only: 0 wins / 2 games -> 0% -> floored to 33%
+        self.assertEqual(p1_row.gw_pct, FLOOR)
+
+        # MWP from played matches only: 0 / 1 -> 0% -> floored to 33%.
+        # If the BYE was wrongly included it would be (3+0)/(2*3)=50%.
+        # We assert via the public OMW% pathway: P2's only opponent is P1,
+        # so P2's OMW% should equal P1's MWP (= floor 33%).
+        p2_row = next(r for r in rows if r.player.pk == self.players[1].pk)
+        self.assertEqual(p2_row.omw_pct, FLOOR)
+
+    def test_opponents_omw_excludes_byes(self):
+        """
+        Regression for the user-reported bug: opponents of a BYE recipient
+        used to see an inflated OMW% (because the BYE win was counted toward
+        the recipient's MWP). With the fix, the BYE round is invisible to
+        the OMW% calculation.
+
+        Setup:
+          R1: P1 BYE,  P2 beats P3 (2-0)
+          R2: P2 beats P1 (2-0)
+
+        P1's played record: 0-1 -> MWP floored to 33%.
+        Old (buggy) code would give P1 MWP = (3+0)/(2*3) = 50%, which would
+        leak into P2's OMW%. The fix keeps P2's OMW% at the floor.
+        """
+        p1, p2, p3, _p4 = self.players
+        r1 = self._round(1)
+        r2 = self._round(2)
+        self._bye(r1, p1)
+        self._played(r1, p2, p3, 2, 0)
+        self._played(r2, p2, p1, 2, 0)
+
+        rows = compute_standings(self.tournament)
+        p2_row = next(r for r in rows if r.player.pk == p2.pk)
+
+        # P2's opponents are P3 (0 played wins) and P1 (0 played wins).
+        # Both have MWP floored to 33%, so OMW% must also be 33%, not the
+        # ~41% the old code would have produced from P1's inflated MWP.
+        self.assertEqual(p2_row.omw_pct, FLOOR)


### PR DESCRIPTION
## Bug

A user reported that a player who received a wild card (BYE) appeared to have **more tiebreaker points** than a player who played and won all of their matches.

## Root cause

`tournaments/scoring.py` was counting a BYE as a regular 2-0 match win:

- The BYE incremented `match_wins` → inflated the recipient's **Match-Win % (MWP)**.
- The BYE added a 2-0 to `game_wins`/`game_losses` → inflated the recipient's **Game-Win % (GWP)**.
- Both inflated values then propagated to opponents via **OMW%** / **OGW%**.

## Official rule (verified against Bandai source)

From the [One Piece Card Game Tournament Rules Manual](https://en.onepiece-cardgame.com/pdf/tournament_rules_manual.pdf), section 5 (\"Calculating Average Values\"):

> **Player Average Match Win Rate** = their match points **(excluding match points from byes)** / participated rounds **(excluding byes)** × 3
>
> **Average Match Win Rates for a Player's Opponent** = the total of the entire opponent's values from (1) / number of games the player participated in.
>
> Numbers under 0.33 are treated as 0.33.

The earlier paragraph also states the average match win rate is calculated **\"excluding byes\"**.

A BYE still awards full match points (it counts as a win for MP), but it is invisible to the tiebreaker percentages — both for the recipient and for their opponents.

## Fix

- `PlayerStats` now tracks `bye_wins` separately from `match_wins`.
- Byes contribute to `match_points` (3 MP each) but are excluded from `matches_played`, the MWP numerator/denominator, and the GWP calculation entirely.
- The opponents list is only appended for played matches, so `OMW%` / `OGW%` cannot see bye-derived data either.
- Standings still show the BYE as a win in the **W** column for record-keeping clarity.

## Tests

New `tournaments/tests/test_scoring.py` adds three regression tests:

1. A BYE awards 3 match points.
2. A BYE recipient's MWP/GWP are not inflated by the BYE.
3. Opponents' OMW% does not absorb the inflation either (the original user-visible bug).

All pass:

\`\`\`
Ran 3 tests in 2.173s

OK
\`\`\`

## Note (out of scope)

The official manual defines only two tiebreakers: Player MWR, then Opponent MWR. Our code additionally tiebreaks on **Game-Win %** and **Opponent Game-Win %** (Magic-style). That pre-existing behaviour is left alone in this PR; happy to open a follow-up issue if strict OP TCG conformance is desired.